### PR TITLE
Fix updating QUrl query parameters with Qt5.

### DIFF
--- a/minitube.pro
+++ b/minitube.pro
@@ -101,7 +101,8 @@ HEADERS += src/video.h \
     src/yt3listparser.h \
     src/ytchannel.h \
     src/yt3.h \
-    src/paginatedvideosource.h
+    src/paginatedvideosource.h \
+    src/compatibility/qurlqueryhelper.h
 SOURCES += src/main.cpp \
     src/searchlineedit.cpp \
     src/urllineedit.cpp \

--- a/src/autocomplete.cpp
+++ b/src/autocomplete.cpp
@@ -26,6 +26,8 @@ $END_LICENSE */
 #include "searchlineedit.h"
 #endif
 
+#include <QListWidget>
+
 #ifndef QT_NO_DEBUG_OUTPUT
 /// Gives human-readable event type information.
 QDebug operator<<(QDebug str, const QEvent * ev) {

--- a/src/autocomplete.h
+++ b/src/autocomplete.h
@@ -26,6 +26,10 @@ class Suggester;
 class Suggestion;
 class SearchLineEdit;
 
+QT_FORWARD_DECLARE_CLASS(QListWidget)
+QT_FORWARD_DECLARE_CLASS(QListWidgetItem)
+QT_FORWARD_DECLARE_CLASS(QLineEdit)
+
 class AutoComplete : public QObject {
 
     Q_OBJECT

--- a/src/channelsuggest.cpp
+++ b/src/channelsuggest.cpp
@@ -20,6 +20,7 @@ $END_LICENSE */
 
 #include "channelsuggest.h"
 #include "networkaccess.h"
+#include "compatibility/qurlqueryhelper.h"
 
 namespace The {
     NetworkAccess* http();
@@ -31,17 +32,12 @@ ChannelSuggest::ChannelSuggest(QObject *parent) : Suggester(parent) {
 
 void ChannelSuggest::suggest(const QString &query) {
     QUrl url("https://www.youtube.com/results");
-#if QT_VERSION >= 0x050000
-        {
-            QUrl &u = url;
-            QUrlQuery url;
-#endif
-    url.addQueryItem("search_type", "search_users");
-    url.addQueryItem("search_query", query);
-#if QT_VERSION >= 0x050000
-            u.setQuery(url);
-        }
-#endif
+    {
+        QUrlQueryHelper urlHelper(url);
+        urlHelper.addQueryItem("search_type", "search_users");
+        urlHelper.addQueryItem("search_query", query);
+    }
+
     QObject *reply = The::http()->get(url);
     connect(reply, SIGNAL(data(QByteArray)), SLOT(handleNetworkData(QByteArray)));
 }

--- a/src/compatibility/qurlqueryhelper.h
+++ b/src/compatibility/qurlqueryhelper.h
@@ -1,0 +1,42 @@
+#ifndef QURLQUERYHELPER_H
+#define QURLQUERYHELPER_H
+
+#include <QtGlobal>
+
+QT_FORWARD_DECLARE_CLASS(QUrl)
+
+#if QT_VERSION >= 0x050000
+#include <QUrlQuery>
+
+class QUrlQueryHelper {
+public:
+    QUrlQueryHelper(QUrl &url) : m_url(url), m_urlQuery(url) {}
+
+    bool hasQueryItem(const QString &itemKey) const {
+        return m_urlQuery.hasQueryItem(itemKey);
+    }
+
+    void addQueryItem(const QString &key, const QString &value) {
+        m_urlQuery.addQueryItem(key, value);
+    }
+
+    void removeQueryItem(const QString &key) {
+        m_urlQuery.removeQueryItem(key);
+    }
+
+    ~QUrlQueryHelper() {
+        m_url.setQuery(m_urlQuery);
+    }
+
+private:
+    QUrlQueryHelper(const QUrlQueryHelper&);
+    QUrlQueryHelper& operator=(const QUrlQueryHelper&);
+
+    QUrl &m_url;
+    QUrlQuery m_urlQuery;
+};
+#else
+typedef QUrl& QUrlQueryHelper;
+#endif  // QT_VERSION >= 0x050000
+
+#endif // QURLQUERYHELPER_H

--- a/src/diskcache.cpp
+++ b/src/diskcache.cpp
@@ -20,6 +20,7 @@ $END_LICENSE */
 
 #include "diskcache.h"
 #include <QtNetwork>
+#include "compatibility/qurlqueryhelper.h"
 
 DiskCache::DiskCache(QObject *parent) : QNetworkDiskCache(parent) { }
 
@@ -43,10 +44,12 @@ QIODevice* DiskCache::prepare(const QNetworkCacheMetaData &metaData) {
 QNetworkCacheMetaData DiskCache::metaData(const QUrl &url) {
     // Remove "key" from query string in order to reuse cache when key changes
     static const QString keyQueryItem = "key";
-    if (url.hasQueryItem(keyQueryItem)) {
-        QUrl url2(url);
-        url2.removeQueryItem(keyQueryItem);
+    QUrl url2(url);
+    QUrlQueryHelper urlHelper(url2);
+    if (urlHelper.hasQueryItem(keyQueryItem)) {
+        urlHelper.removeQueryItem(keyQueryItem);
         return QNetworkDiskCache::metaData(url2);
     }
+
     return QNetworkDiskCache::metaData(url);
 }

--- a/src/iconutils.cpp
+++ b/src/iconutils.cpp
@@ -19,6 +19,7 @@ along with Minitube.  If not, see <http://www.gnu.org/licenses/>.
 $END_LICENSE */
 
 #include "iconutils.h"
+#include <QAction>
 
 QIcon IconUtils::fromTheme(const QString &name) {
     const QLatin1String symbolic("-symbolic");

--- a/src/jsfunctions.cpp
+++ b/src/jsfunctions.cpp
@@ -22,6 +22,7 @@ $END_LICENSE */
 #include "networkaccess.h"
 #include <QDesktopServices>
 #include "constants.h"
+#include "compatibility/qurlqueryhelper.h"
 
 namespace The {
 NetworkAccess* http();
@@ -75,7 +76,11 @@ QString JsFunctions::jsPath() {
 
 void JsFunctions::loadJs() {
     QUrl url(this->url);
-    url.addQueryItem("v", Constants::VERSION);
+    {
+        QUrlQueryHelper urlHelper(url);
+        urlHelper.addQueryItem("v", Constants::VERSION);
+    }
+
     NetworkReply* reply = The::http()->get(url);
     connect(reply, SIGNAL(data(QByteArray)), SLOT(gotJs(QByteArray)));
     connect(reply, SIGNAL(error(QNetworkReply*)), SLOT(errorJs(QNetworkReply*)));

--- a/src/mediaview.cpp
+++ b/src/mediaview.cpp
@@ -50,6 +50,7 @@ $END_LICENSE */
 #include "snapshotsettings.h"
 #endif
 #include "datautils.h"
+#include "compatibility/qurlqueryhelper.h"
 
 namespace The {
 NetworkAccess* http();
@@ -1011,18 +1012,12 @@ void MediaView::shareViaTwitter() {
     Video* video = playlistModel->activeVideo();
     if (!video) return;
     QUrl url("https://twitter.com/intent/tweet");
-#if QT_VERSION >= 0x050000
     {
-        QUrl &u = url;
-        QUrlQuery url;
-#endif
-        url.addQueryItem("via", "minitubeapp");
-        url.addQueryItem("text", video->title());
-        url.addQueryItem("url", video->webpage());
-#if QT_VERSION >= 0x050000
-        u.setQuery(url);
+        QUrlQueryHelper urlHelper(url);
+        urlHelper.addQueryItem("via", "minitubeapp");
+        urlHelper.addQueryItem("text", video->title());
+        urlHelper.addQueryItem("url", video->webpage());
     }
-#endif
     QDesktopServices::openUrl(url);
 }
 
@@ -1030,17 +1025,11 @@ void MediaView::shareViaFacebook() {
     Video* video = playlistModel->activeVideo();
     if (!video) return;
     QUrl url("https://www.facebook.com/sharer.php");
-#if QT_VERSION >= 0x050000
     {
-        QUrl &u = url;
-        QUrlQuery url;
-#endif
-        url.addQueryItem("t", video->title());
-        url.addQueryItem("u", video->webpage());
-#if QT_VERSION >= 0x050000
-        u.setQuery(url);
+        QUrlQueryHelper urlHelper(url);
+        urlHelper.addQueryItem("t", video->title());
+        urlHelper.addQueryItem("u", video->webpage());
     }
-#endif
     QDesktopServices::openUrl(url);
 }
 
@@ -1048,19 +1037,13 @@ void MediaView::shareViaBuffer() {
     Video* video = playlistModel->activeVideo();
     if (!video) return;
     QUrl url("http://bufferapp.com/add");
-#if QT_VERSION >= 0x050000
     {
-        QUrl &u = url;
-        QUrlQuery url;
-#endif
-        url.addQueryItem("via", "minitubeapp");
-        url.addQueryItem("text", video->title());
-        url.addQueryItem("url", video->webpage());
-        url.addQueryItem("picture", video->thumbnailUrl());
-#if QT_VERSION >= 0x050000
-        u.setQuery(url);
+        QUrlQueryHelper urlHelper(url);
+        urlHelper.addQueryItem("via", "minitubeapp");
+        urlHelper.addQueryItem("text", video->title());
+        urlHelper.addQueryItem("url", video->webpage());
+        urlHelper.addQueryItem("picture", video->thumbnailUrl());
     }
-#endif
     QDesktopServices::openUrl(url);
 }
 
@@ -1068,21 +1051,15 @@ void MediaView::shareViaEmail() {
     Video* video = playlistModel->activeVideo();
     if (!video) return;
     QUrl url("mailto:");
-#if QT_VERSION >= 0x050000
     {
-        QUrl &u = url;
-        QUrlQuery url;
-#endif
-        url.addQueryItem("subject", video->title());
-        QString body = video->title() + "\n" +
+        QUrlQueryHelper urlHelper(url);
+        urlHelper.addQueryItem("subject", video->title());
+        const QString body = video->title() + "\n" +
                 video->webpage() + "\n\n" +
                 tr("Sent from %1").arg(Constants::NAME) + "\n" +
                 Constants::WEBSITE;
-        url.addQueryItem("body", body);
-#if QT_VERSION >= 0x050000
-        u.setQuery(url);
+        urlHelper.addQueryItem("body", body);
     }
-#endif
     QDesktopServices::openUrl(url);
 }
 

--- a/src/paginatedvideosource.cpp
+++ b/src/paginatedvideosource.cpp
@@ -23,6 +23,7 @@ $END_LICENSE */
 #include "yt3.h"
 #include "yt3listparser.h"
 #include "datautils.h"
+#include "compatibility/qurlqueryhelper.h"
 
 #include "video.h"
 #include "networkaccess.h"
@@ -110,20 +111,11 @@ void PaginatedVideoSource::loadVideoDetails(const QList<Video*> &videos) {
     }
 
     QUrl url = YT3::instance().method("videos");
-
-#if QT_VERSION >= 0x050000
     {
-        QUrl &u = url;
-        QUrlQuery url;
-#endif
-
-        url.addQueryItem("part", "contentDetails,statistics");
-        url.addQueryItem("id", videoIds);
-
-#if QT_VERSION >= 0x050000
-        u.setQuery(url);
+        QUrlQueryHelper urlHelper(url);
+        urlHelper.addQueryItem("part", "contentDetails,statistics");
+        urlHelper.addQueryItem("id", videoIds);
     }
-#endif
 
     QObject *reply = The::http()->get(url);
     connect(reply, SIGNAL(data(QByteArray)), SLOT(parseVideoDetails(QByteArray)));

--- a/src/updatechecker.cpp
+++ b/src/updatechecker.cpp
@@ -24,6 +24,7 @@ $END_LICENSE */
 #ifdef APP_ACTIVATION
 #include "activation.h"
 #endif
+#include "compatibility/qurlqueryhelper.h"
 
 namespace The {
 NetworkAccess* http();
@@ -36,33 +37,25 @@ UpdateChecker::UpdateChecker() {
 void UpdateChecker::checkForUpdate() {
     QUrl url(QLatin1String(Constants::WEBSITE) + "-ws/release.xml");
 
-#if QT_VERSION >= 0x050000
     {
-        QUrl &u = url;
-        QUrlQuery url;
-#endif
-
-        url.addQueryItem("v", Constants::VERSION);
+        QUrlQueryHelper urlHelper(url);
+        urlHelper.addQueryItem("v", Constants::VERSION);
 
 #ifdef APP_MAC
-        url.addQueryItem("os", "mac");
+        urlHelper.addQueryItem("os", "mac");
 #endif
 #ifdef APP_WIN
-        url.addQueryItem("os", "win");
+        urlHelper.addQueryItem("os", "win");
 #endif
 #ifdef APP_ACTIVATION
         QString t = "demo";
         if (Activation::instance().isActivated()) t = "active";
-        url.addQueryItem("t", t);
+        urlHelper.addQueryItem("t", t);
 #endif
 #ifdef APP_MAC_STORE
-        url.addQueryItem("store", "mac");
+        urlHelper.addQueryItem("store", "mac");
 #endif
-
-#if QT_VERSION >= 0x050000
-        u.setQuery(url);
     }
-#endif
 
     QObject *reply = The::http()->get(url);
     connect(reply, SIGNAL(data(QByteArray)), SLOT(requestFinished(QByteArray)));

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -24,6 +24,7 @@ $END_LICENSE */
 #include "videodefinition.h"
 #include "jsfunctions.h"
 #include "temporary.h"
+#include "compatibility/qurlqueryhelper.h"
 
 namespace The {
 NetworkAccess* http();
@@ -123,28 +124,18 @@ void  Video::getVideoInfo() {
     static const QStringList elTypes = QStringList() << "&el=embedded" << "&el=detailpage" << "&el=vevo" << "";
 
     QUrl url;
-
     if (elIndex == elTypes.size()) {
         // qDebug() << "Trying special embedded el param";
         url = QUrl("https://www.youtube.com/get_video_info");
 
-#if QT_VERSION >= 0x050000
-        {
-            QUrl &u = url;
-            QUrlQuery url;
-#endif
-            url.addQueryItem("video_id", videoId);
-            url.addQueryItem("el", "embedded");
-            url.addQueryItem("gl", "US");
-            url.addQueryItem("hl", "en");
-            url.addQueryItem("eurl", "https://youtube.googleapis.com/v/" + videoId);
-            url.addQueryItem("asv", "3");
-            url.addQueryItem("sts", "1588");
-#if QT_VERSION >= 0x050000
-            u.setQuery(url);
-        }
-#endif
-
+        QUrlQueryHelper urlHelper(url);
+        urlHelper.addQueryItem("video_id", videoId);
+        urlHelper.addQueryItem("el", "embedded");
+        urlHelper.addQueryItem("gl", "US");
+        urlHelper.addQueryItem("hl", "en");
+        urlHelper.addQueryItem("eurl", "https://youtube.googleapis.com/v/" + videoId);
+        urlHelper.addQueryItem("asv", "3");
+        urlHelper.addQueryItem("sts", "1588");
     } else if (elIndex > elTypes.size() - 1) {
         qWarning() << "Cannot get video info";
         loadingStreamUrl = false;
@@ -247,20 +238,13 @@ void Video::parseFmtUrlMap(const QString &fmtUrlMap, bool fromWebPage) {
                 } else {
 
                     QUrl url("http://www.youtube.com/watch");
-
-#if QT_VERSION >= 0x050000
                     {
-                        QUrl &u = url;
-                        QUrlQuery url;
-#endif
-                        url.addQueryItem("v", videoId);
-                        url.addQueryItem("gl", "US");
-                        url.addQueryItem("hl", "en");
-                        url.addQueryItem("has_verified", "1");
-#if QT_VERSION >= 0x050000
-                        u.setQuery(url);
+                        QUrlQueryHelper urlHelper(url);
+                        urlHelper.addQueryItem("v", videoId);
+                        urlHelper.addQueryItem("gl", "US");
+                        urlHelper.addQueryItem("hl", "en");
+                        urlHelper.addQueryItem("has_verified", "1");
                     }
-#endif
                     // qDebug() << "Loading webpage" << url;
                     QObject *reply = The::http()->get(url);
                     connect(reply, SIGNAL(data(QByteArray)), SLOT(scrapeWebPage(QByteArray)));

--- a/src/yt3.cpp
+++ b/src/yt3.cpp
@@ -6,6 +6,7 @@
 #include "jsfunctions.h"
 #include "networkaccess.h"
 #include "constants.h"
+#include "compatibility/qurlqueryhelper.h"
 
 #ifdef APP_EXTRA
 #include "extra.h"
@@ -65,18 +66,12 @@ const QString &YT3::baseUrl() {
 
 void YT3::testApiKey() {
     QUrl url = method("videos");
-#if QT_VERSION >= 0x050000
     {
-        QUrl &u = url;
-        QUrlQuery url;
-#endif
-        url.addQueryItem("part", "id");
-        url.addQueryItem("chart", "mostPopular");
-        url.addQueryItem("maxResults", "1");
-#if QT_VERSION >= 0x050000
-        u.setQuery(url);
+        QUrlQueryHelper urlHelper(url);
+        urlHelper.addQueryItem("part", "id");
+        urlHelper.addQueryItem("chart", "mostPopular");
+        urlHelper.addQueryItem("maxResults", "1");
     }
-#endif
     QObject *reply = The::http()->get(url);
     connect(reply, SIGNAL(finished(QNetworkReply*)), SLOT(testResponse(QNetworkReply*)));
 }
@@ -86,16 +81,9 @@ void YT3::addApiKey(QUrl &url) {
         qDebug() << __PRETTY_FUNCTION__ << "empty key";
         return;
     }
-#if QT_VERSION >= 0x050000
-    {
-        QUrl &u = url;
-        QUrlQuery url(u);
-#endif
-        url.addQueryItem("key", key);
-#if QT_VERSION >= 0x050000
-        u.setQuery(url);
-    }
-#endif
+
+    QUrlQueryHelper urlHelper(url);
+    urlHelper.addQueryItem("key", key);
 }
 
 QUrl YT3::method(const QString &name) {

--- a/src/ytcategories.cpp
+++ b/src/ytcategories.cpp
@@ -26,6 +26,7 @@ $END_LICENSE */
 #include "ytregions.h"
 #include <QtScript>
 #endif
+#include "compatibility/qurlqueryhelper.h"
 
 namespace The {
 NetworkAccess* http();
@@ -40,25 +41,15 @@ void YTCategories::loadCategories(QString language) {
 
 #ifdef APP_YT3
     QUrl url = YT3::instance().method("videoCategories");
-
-#if QT_VERSION >= 0x050000
     {
-        QUrl &u = url;
-        QUrlQuery url(u);
-#endif
-
-        url.addQueryItem("part", "snippet");
-        url.addQueryItem("hl", language);
+        QUrlQueryHelper urlHelper(url);
+        urlHelper.addQueryItem("part", "snippet");
+        urlHelper.addQueryItem("hl", language);
 
         QString regionCode = YTRegions::currentRegionId();
         if (regionCode.isEmpty()) regionCode = "us";
-        url.addQueryItem("regionCode", regionCode);
-
-#if QT_VERSION >= 0x050000
-        u.setQuery(url);
+        urlHelper.addQueryItem("regionCode", regionCode);
     }
-#endif
-
 #else
     QString url = "http://gdata.youtube.com/schemas/2007/categories.cat?hl=" + language;
 #endif

--- a/src/ytchannel.cpp
+++ b/src/ytchannel.cpp
@@ -27,6 +27,7 @@ $END_LICENSE */
 #include "yt3.h"
 #include <QtScript>
 #endif
+#include "compatibility/qurlqueryhelper.h"
 
 namespace The {
 NetworkAccess* http();
@@ -92,31 +93,19 @@ void YTChannel::maybeLoadfromAPI() {
 #ifdef APP_YT3
 
     QUrl url = YT3::instance().method("channels");
-#if QT_VERSION >= 0x050000
     {
-        QUrl &u = url;
-        QUrlQuery url;
-#endif
-        url.addQueryItem("id", channelId);
-        url.addQueryItem("part", "snippet");
-#if QT_VERSION >= 0x050000
-        u.setQuery(url);
+        QUrlQueryHelper urlHelper(url);
+        urlHelper.addQueryItem("id", channelId);
+        urlHelper.addQueryItem("part", "snippet");
     }
-#endif
 
 #else
 
     QUrl url("http://gdata.youtube.com/feeds/api/users/" + channelId);
-#if QT_VERSION >= 0x050000
     {
-        QUrl &u = url;
-        QUrlQuery url;
-#endif
-        url.addQueryItem("v", "2");
-#if QT_VERSION >= 0x050000
-        u.setQuery(url);
+        QUrlQueryHelper urlHelper(url);
+        urlHelper.addQueryItem("v", "2");
     }
-#endif
 
 #endif
 

--- a/src/ytsearch.cpp
+++ b/src/ytsearch.cpp
@@ -32,6 +32,7 @@ $END_LICENSE */
 #else
 #include "ytfeedreader.h"
 #endif
+#include "compatibility/qurlqueryhelper.h"
 
 namespace The {
 NetworkAccess* http();
@@ -62,88 +63,78 @@ void YTSearch::loadVideos(int max, int startIndex) {
     aborted = false;
 
     QUrl url = YT3::instance().method("search");
-
-#if QT_VERSION >= 0x050000
     {
-        QUrl &u = url;
-        QUrlQuery url;
-#endif
-
-        url.addQueryItem("part", "snippet");
-        url.addQueryItem("type", "video");
-
-        url.addQueryItem("maxResults", QString::number(max));
+        QUrlQueryHelper urlHelper(url);
+        urlHelper.addQueryItem("part", "snippet");
+        urlHelper.addQueryItem("type", "video");
+        urlHelper.addQueryItem("maxResults", QString::number(max));
 
         if (startIndex > 1) {
             if (maybeReloadToken(max, startIndex)) return;
-            url.addQueryItem("pageToken", nextPageToken);
+            urlHelper.addQueryItem("pageToken", nextPageToken);
         }
 
         // TODO interesting params
-        // url.addQueryItem("videoSyndicated", "true");
-        // url.addQueryItem("regionCode", "IT");
-        // url.addQueryItem("videoType", "movie");
+        // urlHelper.addQueryItem("videoSyndicated", "true");
+        // urlHelper.addQueryItem("regionCode", "IT");
+        // urlHelper.addQueryItem("videoType", "movie");
 
         if (!searchParams->keywords().isEmpty()) {
             if (searchParams->keywords().startsWith("http://") ||
                     searchParams->keywords().startsWith("https://")) {
-                url.addQueryItem("q", YTSearch::videoIdFromUrl(searchParams->keywords()));
-            } else url.addQueryItem("q", searchParams->keywords());
+                urlHelper.addQueryItem("q", YTSearch::videoIdFromUrl(searchParams->keywords()));
+            } else urlHelper.addQueryItem("q", searchParams->keywords());
         }
 
         if (!searchParams->channelId().isEmpty())
-            url.addQueryItem("channelId", searchParams->channelId());
+            urlHelper.addQueryItem("channelId", searchParams->channelId());
 
         switch (searchParams->sortBy()) {
         case SearchParams::SortByNewest:
-            url.addQueryItem("order", "date");
+            urlHelper.addQueryItem("order", "date");
             break;
         case SearchParams::SortByViewCount:
-            url.addQueryItem("order", "viewCount");
+            urlHelper.addQueryItem("order", "viewCount");
             break;
         case SearchParams::SortByRating:
-            url.addQueryItem("order", "rating");
+            urlHelper.addQueryItem("order", "rating");
             break;
         }
 
         switch (searchParams->duration()) {
         case SearchParams::DurationShort:
-            url.addQueryItem("videoDuration", "short");
+            urlHelper.addQueryItem("videoDuration", "short");
             break;
         case SearchParams::DurationMedium:
-            url.addQueryItem("videoDuration", "medium");
+            urlHelper.addQueryItem("videoDuration", "medium");
             break;
         case SearchParams::DurationLong:
-            url.addQueryItem("videoDuration", "long");
+            urlHelper.addQueryItem("videoDuration", "long");
             break;
         }
 
         switch (searchParams->time()) {
         case SearchParams::TimeToday:
-            url.addQueryItem("publishedAfter", RFC3339toString(QDateTime::currentDateTimeUtc().addSecs(-60*60*24)));
+            urlHelper.addQueryItem("publishedAfter", RFC3339toString(QDateTime::currentDateTimeUtc().addSecs(-60*60*24)));
             break;
         case SearchParams::TimeWeek:
-            url.addQueryItem("publishedAfter", RFC3339toString(QDateTime::currentDateTimeUtc().addSecs(-60*60*24*7)));
+            urlHelper.addQueryItem("publishedAfter", RFC3339toString(QDateTime::currentDateTimeUtc().addSecs(-60*60*24*7)));
             break;
         case SearchParams::TimeMonth:
-            url.addQueryItem("publishedAfter", RFC3339toString(QDateTime::currentDateTimeUtc().addSecs(-60*60*24*30)));
+            urlHelper.addQueryItem("publishedAfter", RFC3339toString(QDateTime::currentDateTimeUtc().addSecs(-60*60*24*30)));
             break;
         }
 
         if (searchParams->publishedAfter()) {
-            url.addQueryItem("publishedAfter", RFC3339toString(QDateTime::fromTime_t(searchParams->publishedAfter()).toUTC()));
+            urlHelper.addQueryItem("publishedAfter", RFC3339toString(QDateTime::fromTime_t(searchParams->publishedAfter()).toUTC()));
         }
 
         switch (searchParams->quality()) {
         case SearchParams::QualityHD:
-            url.addQueryItem("videoDefinition", "high");
+            urlHelper.addQueryItem("videoDefinition", "high");
             break;
         }
-
-#if QT_VERSION >= 0x050000
-        u.setQuery(url);
     }
-#endif
 
     lastUrl = url;
 
@@ -183,72 +174,66 @@ void YTSearch::loadVideos(int max, int startIndex) {
     aborted = false;
 
     QUrl url("http://gdata.youtube.com/feeds/api/videos/");
-#if QT_VERSION >= 0x050000
     {
-        QUrl &u = url;
-        QUrlQuery url;
-#endif
+        QUrlQueryHelper urlHelper(url);
 
-        url.addQueryItem("v", "2");
-        url.addQueryItem("max-results", QString::number(max));
-        url.addQueryItem("start-index", QString::number(startIndex));
+        urlHelper.addQueryItem("v", "2");
+        urlHelper.addQueryItem("max-results", QString::number(max));
+        urlHelper.addQueryItem("start-index", QString::number(startIndex));
 
         if (!searchParams->keywords().isEmpty()) {
             if (searchParams->keywords().startsWith("http://") ||
                     searchParams->keywords().startsWith("https://")) {
-                url.addQueryItem("q", YTSearch::videoIdFromUrl(searchParams->keywords()));
-            } else url.addQueryItem("q", searchParams->keywords());
+                urlHelper.addQueryItem("q", YTSearch::videoIdFromUrl(searchParams->keywords()));
+            } else urlHelper.addQueryItem("q", searchParams->keywords());
         }
 
         if (!searchParams->channelId().isEmpty())
-            url.addQueryItem("author", searchParams->channelId());
+            urlHelper.addQueryItem("author", searchParams->channelId());
 
         switch (searchParams->sortBy()) {
         case SearchParams::SortByNewest:
-            url.addQueryItem("orderby", "published");
+            urlHelper.addQueryItem("orderby", "published");
             break;
         case SearchParams::SortByViewCount:
-            url.addQueryItem("orderby", "viewCount");
+            urlHelper.addQueryItem("orderby", "viewCount");
             break;
         case SearchParams::SortByRating:
-            url.addQueryItem("orderby", "rating");
+            urlHelper.addQueryItem("orderby", "rating");
             break;
         }
 
         switch (searchParams->duration()) {
         case SearchParams::DurationShort:
-            url.addQueryItem("duration", "short");
+            urlHelper.addQueryItem("duration", "short");
             break;
         case SearchParams::DurationMedium:
-            url.addQueryItem("duration", "medium");
+            urlHelper.addQueryItem("duration", "medium");
             break;
         case SearchParams::DurationLong:
-            url.addQueryItem("duration", "long");
+            urlHelper.addQueryItem("duration", "long");
             break;
         }
 
         switch (searchParams->time()) {
         case SearchParams::TimeToday:
-            url.addQueryItem("time", "today");
+            urlHelper.addQueryItem("time", "today");
             break;
         case SearchParams::TimeWeek:
-            url.addQueryItem("time", "this_week");
+            urlHelper.addQueryItem("time", "this_week");
             break;
         case SearchParams::TimeMonth:
-            url.addQueryItem("time", "this_month");
+            urlHelper.addQueryItem("time", "this_month");
             break;
         }
 
         switch (searchParams->quality()) {
         case SearchParams::QualityHD:
-            url.addQueryItem("hd", "true");
+            urlHelper.addQueryItem("hd", "true");
             break;
         }
 
-#if QT_VERSION >= 0x050000
-        u.setQuery(url);
     }
-#endif
     QObject *reply = The::http()->get(url);
     connect(reply, SIGNAL(data(QByteArray)), SLOT(parseResults(QByteArray)));
     connect(reply, SIGNAL(error(QNetworkReply*)), SLOT(requestError(QNetworkReply*)));


### PR DESCRIPTION
	- Add QUrlQueryHelper for compatibility with Qt5.
	- Use QUrlQueryHelper class and remove Qt5 version ifdefs.

When I tried to build Minitube with Qt5.4 I got some compilation errors.
After fixing them I realized that some query parameters didn't contain the Google API key.
With this pull-request I'm trying to fix both issues. Could you take a look please?