### PR TITLE
Fix compiler warnings reported by clang.

### DIFF
--- a/src/channelitemdelegate.cpp
+++ b/src/channelitemdelegate.cpp
@@ -56,6 +56,7 @@ void ChannelItemDelegate::paint( QPainter* painter,
 void ChannelItemDelegate::paintAggregate(QPainter* painter,
                                           const QStyleOptionViewItem& option,
                                           const QModelIndex& index) const {
+    Q_UNUSED(index);
     painter->save();
 
     painter->translate(option.rect.topLeft());
@@ -73,6 +74,7 @@ void ChannelItemDelegate::paintAggregate(QPainter* painter,
 void ChannelItemDelegate::paintUnwatched(QPainter* painter,
                                           const QStyleOptionViewItem& option,
                                           const QModelIndex& index) const {
+    Q_UNUSED(index);
     painter->save();
 
     painter->translate(option.rect.topLeft());

--- a/src/channelview.cpp
+++ b/src/channelview.cpp
@@ -202,7 +202,7 @@ void ChannelView::leaveEvent(QEvent *event) {
     // channelsModel->clearHover();
 }
 
-void ChannelView::itemEntered(const QModelIndex &index) {
+void ChannelView::itemEntered(const QModelIndex &) {
     // channelsModel->setHoveredRow(index.row());
 }
 
@@ -285,6 +285,7 @@ void ChannelView::toggleShowUpdated(bool enable) {
 }
 
 void ChannelView::updateQuery(bool transition) {
+    Q_UNUSED(transition);
     errorMessage.clear();
     if (!Database::exists()) return;
 

--- a/src/downloadmodel.h
+++ b/src/downloadmodel.h
@@ -46,9 +46,9 @@ public slots:
     void updatePlayIcon();
 
 private:
-    int columnCount() { return 1; }
+    int columnCount(const QModelIndex &/*parent*/ = QModelIndex()) const { return 1; }
 
-    DownloadManager *downloadManager;
+    DownloadManager *const downloadManager;
     int hoveredRow;
     bool playIconHovered;
     bool playIconPressed;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -887,7 +887,7 @@ void MainWindow::goBack() {
 }
 
 void MainWindow::showWidget(QWidget* widget, bool transition) {
-
+    Q_UNUSED(transition);
     if (compactViewAct->isChecked())
         compactViewAct->toggle();
 

--- a/src/mediaview.cpp
+++ b/src/mediaview.cpp
@@ -64,12 +64,13 @@ MediaView* MediaView::instance() {
     return i;
 }
 
-MediaView::MediaView(QWidget *parent) : QWidget(parent),
-    stopped(false),
+MediaView::MediaView(QWidget *parent) : QWidget(parent)
+    , stopped(false)
+    , downloadItem(0)
     #ifdef APP_SNAPSHOT
-    snapshotSettings(0),
+    , snapshotSettings(0)
     #endif
-    downloadItem(0) { }
+    { }
 
 void MediaView::initialize() {
     QBoxLayout *layout = new QVBoxLayout(this);
@@ -213,6 +214,7 @@ void MediaView::search(SearchParams *searchParams) {
 }
 
 void MediaView::setVideoSource(VideoSource *videoSource, bool addToHistory, bool back) {
+    Q_UNUSED(back);
     stopped = false;
 
 #ifdef APP_ACTIVATION
@@ -900,6 +902,7 @@ void MediaView::startDownloading() {
 }
 
 void MediaView::sliderMoved(int value) {
+    Q_UNUSED(value);
 #ifdef APP_PHONON
 #ifndef APP_PHONON_SEEK
 

--- a/src/paginatedvideosource.cpp
+++ b/src/paginatedvideosource.cpp
@@ -35,9 +35,9 @@ QHash<QString, QAction*>* globalActions();
 
 PaginatedVideoSource::PaginatedVideoSource(QObject *parent) : VideoSource(parent)
   , tokenTimestamp(0)
-  , reloadingToken(false)
   , currentMax(0)
   , currentStartIndex(0)
+  , reloadingToken(false)
   , asyncDetails(false) { }
 
 bool PaginatedVideoSource::hasMoreVideos() {

--- a/src/refinesearchbutton.cpp
+++ b/src/refinesearchbutton.cpp
@@ -40,7 +40,7 @@ void RefineSearchButton::paintBackground() const {
 
 }
 
-void RefineSearchButton::paintEvent(QPaintEvent *event) {
+void RefineSearchButton::paintEvent(QPaintEvent *) {
     // QPushButton::paintEvent(event);
     QPainter painter(this);
     painter.setRenderHints(QPainter::Antialiasing, true);

--- a/src/regionsview.h
+++ b/src/regionsview.h
@@ -27,7 +27,7 @@ $END_LICENSE */
 #endif
 #include "view.h"
 
-class YTRegion;
+struct YTRegion;
 
 class RegionsView : public QWidget, public View {
 

--- a/src/searchlineedit.cpp
+++ b/src/searchlineedit.cpp
@@ -45,12 +45,12 @@ void ClearButton::leaveEvent(QEvent *e) {
     hovered = false;
 }
 
-void ClearButton::mousePressEvent(QEvent *e) {
+void ClearButton::mousePressEvent(QMouseEvent *e) {
     Q_UNUSED(e);
     mousePressed = true;
 }
 
-void ClearButton::mouseReleaseEvent(QEvent *e) {
+void ClearButton::mouseReleaseEvent(QMouseEvent *e) {
     Q_UNUSED(e);
     mousePressed = false;
 }

--- a/src/searchlineedit.h
+++ b/src/searchlineedit.h
@@ -33,8 +33,8 @@ protected:
     void enterEvent(QEvent *e);
     void leaveEvent(QEvent *e);
 
-    void mousePressEvent(QEvent *e);
-    void mouseReleaseEvent(QEvent *e);
+    void mousePressEvent(QMouseEvent *e);
+    void mouseReleaseEvent(QMouseEvent *e);
 
 private:
     bool hovered;

--- a/src/standardfeedsview.h
+++ b/src/standardfeedsview.h
@@ -28,7 +28,7 @@ $END_LICENSE */
 #include "view.h"
 
 class VideoSource;
-class YTCategory;
+struct YTCategory;
 class YTStandardFeed;
 
 class StandardFeedsView : public QWidget, public View {


### PR DESCRIPTION
This request should fix few minor compiler warnings such as reordered fields in initialization list and unused parameters. Also there were some methods like 'columnCount()' with signature that differs from base class. Please check that I fixed them correctly.