### PR TITLE
Be careful about the lifetime of stack variables

### DIFF
--- a/src/datautils.cpp
+++ b/src/datautils.cpp
@@ -50,7 +50,9 @@ uint DataUtils::parseIsoPeriod(const QString &isoPeriod) {
 
     uint days = 0, hours = 0, minutes = 0, seconds = 0;
 
-    const char *ptr = isoPeriod.toStdString().c_str();
+    QByteArray ba = isoPeriod.toLocal8Bit();
+    const char *ptr = ba.data();
+    
     while (*ptr) {
         if(*ptr == 'P' || *ptr == 'T') {
             ptr++;


### PR DESCRIPTION
This commit fixes minitube hanging indefinitely on OpenBSD while showing search results.

ptr is pointing to free'd memory, causing an infinite loop when parsing video duration property into src/paginatedvideosource.cpp (L148)

See also the following links for a better explanation:

http://blog.aaronballman.com/2011/07/returning-stack-based-values/

https://wiki.qt.io/Qt_project_org_faq#How_can_I_convert_a_QString_to_char.2A_and_vice_versa.3F