### PR TITLE
Multimonitor improvements

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1211,6 +1211,12 @@ void MainWindow::moveEvent(QMoveEvent *e) {
     adjustMessageLabelPosition();
 }
 
+void MainWindow::leaveEvent(QEvent *e) {
+    Q_UNUSED(e);
+    showFullscreenPlaylist(false);
+    showFullscreenToolbar(false);
+}
+
 void MainWindow::fullscreen() {
 
     if (compactViewAct->isChecked())

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -259,15 +259,15 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *e) {
         if (isHoveringVideo) {
             QMouseEvent *mouseEvent = static_cast<QMouseEvent*> (e);
             const int x = mouseEvent->pos().x();
+            const int y = mouseEvent->pos().y();
 
             if (mediaView->isPlaylistVisible()) {
                 if (x > 5) mediaView->setPlaylistVisible(false);
             } else {
-                if (x >= 0 && x < 5) mediaView->setPlaylistVisible(true);
+                if (x >= 0 && x < 5 && (y <= 150 || y >= height() - 150)) mediaView->setPlaylistVisible(true);
             }
 
 #ifndef APP_MAC
-            const int y = mouseEvent->pos().y();
             if (mainToolBar->isVisible()) {
                 if (y > 5) mainToolBar->setVisible(false);
             } else {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -103,6 +103,7 @@ protected:
     void dropEvent(QDropEvent *e);
     void resizeEvent(QResizeEvent *e);
     void moveEvent(QMoveEvent *e);
+    void leaveEvent(QEvent *e);
 
 private slots:
     void lazyInit();


### PR DESCRIPTION
Hi,

these 2 commits are an attempt to improve the usability on systems with multiple monitors.

* Hide playlist when mouse leaves window: When Minitube is in fullscreen mode, moving the mouse to the left or top edge of the screen pops up the toolbar/playlist. When the mouse leaves the window, the toolbar/playlist should be hidden again, to make room for the video.

* Only show playlist when mouse moves to top/bottom left of screen: When Minitube is on the right screen in fullscreen mode, and I want to move the mouse to the left screen, it always pops up the playlist. This commit changes it, so the playlist only pops up when the mouse moves to the top/bottom left edge.