### PR TITLE
Add Fedora installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,18 @@ To be able to build on a Debian (or derivative) system:
 
     $ sudo apt-get install build-essential qttools5-dev-tools qt5-qmake qtscript5-dev libphonon4qt5-dev libqt5sql5-sqlite qt5-default
 
+For Fedora 23:
+
+    $ sudo dnf install gcc-c++ qt5-qtbase-devel qt5-qtscript-devel qt5-linguist phonon-qt5-devel
+
 Compiling:
 
     $ qmake "DEFINES += APP_GOOGLE_API_KEY=YourAPIKeyHere"
     $ make
 
 Beware of the Qt 4 version of qmake!
+
+Use qmake-qt5 on Fedora systems.
 
 Running:
 


### PR DESCRIPTION
I recently needed to compile for a Fedora OS and detailed the required packages in the README, as the version by rpmfusion-free is still the 2.3 version.
