### PR TITLE
Fix build

### DIFF
--- a/src/ytregions.cpp
+++ b/src/ytregions.cpp
@@ -89,7 +89,7 @@ const YTRegion &YTRegions::localRegion() {
         for (const YTRegion &r : list()) {
             if (r.id == country) return r;
         }
-        return YTRegion();
+        YTRegion();
     }();
     return region;
 }


### PR DESCRIPTION
Hi!

First of all I do not know C++ and so it may be platform specific.

Minitube was failing to build in FreeBSD 10.{3,4}-RELEASE (but built fine in 11.1-RELEASE) without that patch:

`--- build/obj/ytregions.o ---
src/ytregions.cpp:92:9: error: return type 'YTRegion' must match previous return type 'const YTRegion' when lambda expression has unspecified explicit return type
        return YTRegion();
        ^
1 error generated.
*** [build/obj/ytregions.o] Error code 1`