### PR TITLE
Update AppStream metadata

### DIFF
--- a/minitube.appdata.xml
+++ b/minitube.appdata.xml
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<application>
-  <id type="desktop">minitube.desktop</id>
+<component>
+  <name>Minitube</name>
+  <id>org.tordini.flavio.minitube</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <license>GPL-3.0+</license>
+  <project_license>GPL-3.0+</project_license>
   <summary>YouTube app</summary>
   <description>
     <p>
-      Minitube is a YouTube desktop application.
+      Minitube is a YouTube desktop application. It is written in C++ using the Qt framework.
     </p>
   </description>
   <url type="homepage">http://flavio.tordini.org/minitube</url>
   <screenshots>
-    <screenshot type="default">http://flavio.tordini.org/files/minitube/minitube-04.jpg</screenshot>
-    <screenshot>http://flavio.tordini.org/files/minitube/minitube-03.jpg</screenshot>
-    <screenshot>http://flavio.tordini.org/files/minitube/minitube-02.jpg</screenshot>
-    <screenshot>http://flavio.tordini.org/files/minitube/minitube-01.jpg</screenshot>
+    <screenshot type="default"><image>http://flavio.tordini.org/files/minitube/minitube-04.jpg</image></screenshot>
+    <screenshot><image>http://flavio.tordini.org/files/minitube/minitube-03.jpg</image></screenshot>
+    <screenshot><image>http://flavio.tordini.org/files/minitube/minitube-02.jpg</image></screenshot>
+    <screenshot><image>http://flavio.tordini.org/files/minitube/minitube-01.jpg</image></screenshot>
   </screenshots>
-</application>
+</component>


### PR DESCRIPTION
The AppStream metadata file no longer follows the current standard. This commit updates it.