### PR TITLE
Subscribe from channel list

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -565,7 +565,7 @@ void MainWindow::createActions() {
     action->setEnabled(false);
     connect(action, SIGNAL(triggered()), mediaView, SLOT(toggleSubscription()));
     actionMap.insert("subscribeChannel", action);
-    mediaView->updateSubscriptionAction(0, false);
+    mediaView->updateSubscriptionActionForVideo(0, false);
 
     QString shareTip = tr("Share the current video using %1");
 

--- a/src/mediaview.cpp
+++ b/src/mediaview.cpp
@@ -914,15 +914,15 @@ void MediaView::updateSubscriptionAction(bool subscribed) {
     QString subscribeTip;
     QString subscribeText;
 
-    if (channelId.isEmpty()) {
+    if (currentSubscriptionChannelId.isEmpty()) {
         subscribeText = subscribeAction->property("originalText").toString();
         subscribeAction->setEnabled(false);
     } else if (subscribed) {
-        subscribeText = tr("Unsubscribe from %1").arg(channelTitle);
+        subscribeText = tr("Unsubscribe from %1").arg(currentSubscriptionChannelTitle);
         subscribeTip = subscribeText;
         subscribeAction->setEnabled(true);
     } else {
-        subscribeText = tr("Subscribe to %1").arg(channelTitle);
+        subscribeText = tr("Subscribe to %1").arg(currentSubscriptionChannelTitle);
         subscribeTip = subscribeText;
         subscribeAction->setEnabled(true);
     }
@@ -939,8 +939,6 @@ void MediaView::updateSubscriptionAction(bool subscribed) {
 }
 
 void MediaView::updateSubscriptionActionForChannel(const QString & channelId) {
-    currentChannelId = channelId;
-
     QString channelTitle = tr("channel");
     YTChannel *channel = YTChannel::forId(channelId);
     if (nullptr != channel && !channel->getDisplayName().isEmpty()) {

--- a/src/mediaview.h
+++ b/src/mediaview.h
@@ -56,6 +56,7 @@ public:
     PlaylistModel *getPlaylistModel() { return playlistModel; }
     const QString &getCurrentVideoId();
     void updateSubscriptionAction(Video *video, bool subscribed);
+    void updateSubscriptionActionForChannel(const QString & channelId);
     VideoArea *getVideoArea() { return videoAreaWidget; }
     void reloadCurrentVideo();
 
@@ -132,6 +133,8 @@ private:
     QTimer *errorTimer;
     Video *skippedVideo;
     QString currentVideoId;
+
+    QString currentChannelId;
 
 #ifdef APP_ACTIVATION
     QTimer *demoTimer;

--- a/src/mediaview.h
+++ b/src/mediaview.h
@@ -55,7 +55,7 @@ public:
     int getHistoryIndex();
     PlaylistModel *getPlaylistModel() { return playlistModel; }
     const QString &getCurrentVideoId();
-    void updateSubscriptionAction(Video *video, bool subscribed);
+    void updateSubscriptionActionForVideo(Video *video, bool subscribed);
     void updateSubscriptionActionForChannel(const QString & channelId);
     VideoArea *getVideoArea() { return videoAreaWidget; }
     void reloadCurrentVideo();
@@ -97,6 +97,7 @@ public slots:
     void goForward();
     void toggleSubscription();
     void adjustWindowSize();
+    void updateSubscriptionAction(bool subscribed);
 
 private slots:
     void onItemActivated(const QModelIndex &index);
@@ -134,7 +135,8 @@ private:
     Video *skippedVideo;
     QString currentVideoId;
 
-    QString currentChannelId;
+    QString currentSubscriptionChannelId;
+    QString currentSubscriptionChannelTitle;
 
 #ifdef APP_ACTIVATION
     QTimer *demoTimer;


### PR DESCRIPTION
When the list of videos for a channel is open in the sidebar, make that channel the target of the subscription action. Fixes #136.

Note that when `YTChannel` doesn't know the title of the channel, this just uses `tr("channel")` in place of the channel name in the text of the action; this is kind of a quick hack.