### PR TITLE
Remove useless doubled code

### DIFF
--- a/src/playlistmodel.cpp
+++ b/src/playlistmodel.cpp
@@ -123,12 +123,6 @@ void PlaylistModel::setActiveRow(int row, bool notify) {
         Video *previousVideo = m_activeVideo;
         m_activeVideo = videoAt(row);
 
-        int oldactiverow = m_activeRow;
-
-        if (rowExists(oldactiverow))
-            emit dataChanged(createIndex(oldactiverow, 0),
-                             createIndex(oldactiverow, columnCount() - 1));
-
         emit dataChanged(createIndex(m_activeRow, 0), createIndex(m_activeRow, columnCount() - 1));
         if (notify) emit activeVideoChanged(m_activeVideo, previousVideo);
 


### PR DESCRIPTION
oldacriverow is same as m_activeRow and m_activeRow is same as row and we check `rowExist(row)` so checking `rowExist(oldactiverow)` is same thing and useless then 
`emit dataChanged(createIndex(oldactiverow, 0),
                             createIndex(oldactiverow, columnCount() - 1));`
is always called two times because we already checked that row exist and oldactiverow is same as m_activeRow

or am i wrong?