### PR TITLE
Fixed crash when dragging an item to the end of the playlist

### DIFF
--- a/src/playlistmodel.cpp
+++ b/src/playlistmodel.cpp
@@ -416,7 +416,11 @@ bool PlaylistModel::dropMimeData(const QMimeData *data,
 
         // and then add them again at the new position
         beginInsertRows(QModelIndex(), beginRow, beginRow);
-        videos.insert(beginRow, video);
+        if (beginRow >= videos.size()) {
+            videos.push_back(video);
+        } else {
+            videos.insert(beginRow, video);
+        }
         endInsertRows();
     }
 


### PR DESCRIPTION
The app crashes when moving an playlist item to the end of the list via drag and drop due an out of bounds array access.
This change fixes this problem