### PR TITLE
Add launchable tag to metainfo.xml

### DIFF
--- a/org.tordini.flavio.minitube.metainfo.xml
+++ b/org.tordini.flavio.minitube.metainfo.xml
@@ -2,6 +2,7 @@
 <component type="desktop-application">
   <name>Minitube</name>
   <id>org.tordini.flavio.minitube</id>
+  <launchable type="desktop-id">minitube.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <summary>YouTube app</summary>


### PR DESCRIPTION
This is needed for appstream-generator to find the associated desktop file.

See also: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-launchable