### PR TITLE
Add Network to .desktop Categories

### DIFF
--- a/minitube.desktop
+++ b/minitube.desktop
@@ -17,7 +17,7 @@ Exec=minitube -platform xcb
 Terminal=false
 Type=Application
 Icon=minitube
-Categories=AudioVideo;Video;Qt;
+Categories=AudioVideo;Video;Network;Qt;
 StartupNotify=false
 Actions=TogglePlaying;Next;Previous;StopAfterThis;
 


### PR DESCRIPTION
No YouTube without Internet, which is a category in Xfce's menu where I keep looking for MiniTube, only to find it in Multimedia alone.

This should make it show up in both.